### PR TITLE
bump omniauth-oauth2 version requirement to 1.2.x 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'omniauth-oauth2', "~>1.1.1", :git => 'git://github.com/intridea/omniauth-oauth2.git'
+gem 'omniauth-oauth2', "~> 1.2.0"
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,35 @@
-GIT
-  remote: git://github.com/intridea/omniauth-oauth2.git
-  revision: 8a7a97ecbdb71c04b96bfa47dbc465d5d931f694
-  specs:
-    omniauth-oauth2 (1.1.1)
-      oauth2 (~> 0.9.0)
-      omniauth (~> 1.0)
-
 PATH
   remote: .
   specs:
-    omniauth-paypal (1.2.1)
-      omniauth-oauth2 (~> 1.1.0)
+    omniauth-paypal (1.2.2)
+      omniauth-oauth2 (~> 1.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    faraday (0.8.8)
-      multipart-post (~> 1.2.0)
-    hashie (2.0.5)
-    httpauth (0.2.0)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
+    hashie (3.3.1)
     json (1.8.0)
-    jwt (0.1.8)
-      multi_json (>= 1.5)
-    multi_json (1.8.0)
+    jwt (1.0.0)
+    multi_json (1.10.1)
     multi_xml (0.5.5)
-    multipart-post (1.2.0)
-    oauth2 (0.9.2)
-      faraday (~> 0.8)
-      httpauth (~> 0.2)
-      jwt (~> 0.1.4)
-      multi_json (~> 1.0)
+    multipart-post (2.0.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
-    omniauth (1.1.4)
-      hashie (>= 1.2, < 3)
-      rack
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
+    omniauth-oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      multi_json (~> 1.3)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     rack (1.5.2)
     rake (10.1.0)
     rspec (2.14.1)
@@ -52,7 +46,7 @@ PLATFORMS
 
 DEPENDENCIES
   json
-  omniauth-oauth2 (~> 1.1.1)!
+  omniauth-oauth2 (~> 1.2.0)
   omniauth-paypal!
   rake
   rspec (~> 2.14)

--- a/omniauth-paypal.gemspec
+++ b/omniauth-paypal.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2.0'
 
   s.add_development_dependency 'rspec', '~> 2.14'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
for compatibility with omniauth-stripe-connect
