### PR TITLE
Update Auth Hash Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,32 +28,6 @@ end
 
 Log In With PayPal information can be found on https://developer.paypal.com/webapps/developer/docs/integration/direct/log-in-with-paypal/
 
-The possible attributes to be returned at the moment are:
-
-```ruby
-info['name']
-info['email']
-info['first_name'] # also available as given_name
-info['last_name'] # also available as family_name
-info['location']
-info['name']
-info['phone']
-
-extra['account_creation_date']
-extra['account_type']
-extra['address']['country']
-extra['address']['locality']
-extra['address']['postal_code']
-extra['address']['region']
-extra['address']['street_address']
-extra['language']
-extra['locale']
-extra['verified_account']
-extra['zoneinfo']
-extra['age_range']
-extra['birthday']
-```
-
 The actual set of attributes returned depends on the scopes set. The currently available scopes are:
 
 ```
@@ -68,7 +42,7 @@ https://uri.paypal.com/services/expresscheckout
 
 (those last 2 are scope names, not links)
 
-For more details see the PayPal [list of attributes](https://developer.paypal.com/webapps/developer/docs/integration/direct/log-in-with-paypal/detailed/#attributes).
+For more details see the PayPal [list of attributes](https://developer.paypal.com/docs/integration/direct/identity/attributes/).
 
 ## Registering for an API key
 
@@ -76,43 +50,68 @@ To register your application for Log In With PayPal head over to the [PayPal Dev
 
 [A full tutorial is available](http://cristianobetta.com/blog/2013/09/27/integrating-login-with-paypal-into-rails/) on how to use Omniauth, Login With PayPal, and the PayPal Developer portal.
 
+If the Paypal Sandbox does not like connecting with `localhost` for authentication during development, tools like [ngrok](https://ngrok.com) should be quite useful. For example, if using Rails, start the server with:
+
+```
+ngrok http 3000
+```
+
+and then set the return URL for the sandbox login app to the exposed `ngrok` server:
+
+```
+http://fe04daed.ngrok.io/users/auth/paypal/callback
+```
+
 ## Example of result auth hash
+
 With all scopes requested.
 
-```yaml
-provider: paypal
-uid: bathjJwvdhKjgfgh8Jd745J7dh5Qkgflbnczd65dfnw
-info:
-  name: John Smith
-  email: example@example.com
-  first_name: John
-  last_name: Smith
-  given_name: John
-  family_name: Smith
-  location: Moscow
-  name: John Smith
-  phone: "71234567890"
-credentials:
-  token: <token>
-  refresh_token: <refresh token>
-  expires_at: 1355082790
-  expires: true
-extra:
-  account_creation_date: "2008-04-21"
-  account_type: PERSONAL
-  user_id: https://www.paypal.com/webapps/auth/identity/user/bathjJwvdhKjgfgh8Jd745J7dh5Qkgflbnczd65dfnw
-  address:
-    country: US
-    locality: San Jose
-    postal_code: "95131"
-    region: CA
-    street_address: 1 Main St
-  language: en_US
-  locale: en_US
-  verified_account: true
-  zoneinfo: America/Los_Angeles
-  age_range: 31-35
-  birthday: "1982-01-01"
+```ruby
+{
+  "provider" => "paypal",
+  "uid" => "K43VMDJ6KaRJgMVUFRGT3hqpdnhg1tDYLmlPgxl1HRE",
+  "info" => {
+    "name" => "John Smith",
+    "email" => "john.smith@test.com",
+    "first_name" => "John",
+    "last_name" => "Smith",
+    "location" => "Wolverhampton, West Midlands",
+    "phone" => "0356739226"
+  },
+  "credentials" => {
+    "token" => "A103.rHsfH5P3to...",
+    "refresh_token"=> "R103.DYHqCcnXAS...",
+    "expires_at" => 1472691158,
+    "expires" => true
+  },
+  "extra" => {
+    "raw_info" => {
+      "payer_id" => "6ZGXTKGQ3L35N",
+      "family_name" => "Smith",
+      "verified" => "true",
+      "name" => "John Smith",
+      "account_type" => "PERSONAL",
+      "given_name" => "John",
+      "user_id" => "https://www.paypal.com/webapps/auth/identity/user/K43VMDJ6KaRJgMVUFRGT3hqpdnhg1tDYLmlPgxl1HRE",
+      "address" => {
+        "postal_code" => "W12 4LQ",
+        "locality" => "Wolverhampton",
+        "region" => "West Midlands",
+        "country" => "GB",
+        "street_address" => "1 Main Terrace"
+      },
+      "verified_account" => "true",
+      "language" => "en_GB",
+      "zoneinfo" => "America/Los_Angeles",
+      "locale" => "en_GB",
+      "phone_number" => "0356739226",
+      "account_creation_date" => "2016-08-30",
+      "email" => "john.smith@test.com",
+      "age_range" => "36-40",
+      "birthday" => "1975-10-10"
+    }
+  }
+}
 ```
 
 ## Contributing

--- a/lib/omniauth/strategies/paypal.rb
+++ b/lib/omniauth/strategies/paypal.rb
@@ -22,31 +22,18 @@ module OmniAuth
       uid { @parsed_uid ||= (/\/([^\/]+)\z/.match raw_info['user_id'])[1] } #https://www.paypal.com/webapps/auth/identity/user/baCNqjGvIxzlbvDCSsfhN3IrQDtQtsVr79AwAjMxekw => baCNqjGvIxzlbvDCSsfhN3IrQDtQtsVr79AwAjMxekw
 
       info do
-        prune!({
-                   'name' => raw_info['name'],
-                   'email' => raw_info['email'],
-                   'first_name' => raw_info['given_name'],
-                   'last_name' => raw_info['family_name'],
-                   'given_name' => raw_info['given_name'],
-                   'family_name' => raw_info['family_name'],
-                   'location' => (raw_info['address'] || {})['locality'],
-                   'phone' => raw_info['phone_number']
-               })
+        prune!(
+          name: raw_info['name'],
+          email: raw_info['email'],
+          first_name: raw_info['given_name'],
+          last_name: raw_info['family_name'],
+          location: build_user_location,
+          phone: raw_info['phone_number']
+        )
       end
 
       extra do
-        prune!({
-                   'account_type' => raw_info['account_type'],
-                   'user_id' => raw_info['user_id'],
-                   'address' => raw_info['address'],
-                   'verified_account' => (raw_info['verified_account'] == 'true'),
-                   'language' => raw_info['language'],
-                   'zoneinfo' => raw_info['zoneinfo'],
-                   'locale' => raw_info['locale'],
-                   'account_creation_date' => raw_info['account_creation_date'],
-                   'age_range' => raw_info['age_range'],
-                   'birthday' => raw_info['birthday']
-               })
+        prune!('raw_info' => raw_info)
       end
 
       def setup_phase
@@ -69,20 +56,28 @@ module OmniAuth
       end
 
       private
-        def load_identity
-          access_token.options[:mode] = :query
-          access_token.options[:param_name] = :access_token
-          access_token.options[:grant_type] = :authorization_code
-          access_token.get('/v1/identity/openidconnect/userinfo', { :params => { :schema => 'openid'}}).parsed || {}
-        end
 
-        def prune!(hash)
-          hash.delete_if do |_, value|
-            prune!(value) if value.is_a?(Hash)
-            value.nil? || (value.respond_to?(:empty?) && value.empty?)
-          end
-        end
+      def load_identity
+        access_token.options[:mode] = :query
+        access_token.options[:param_name] = :access_token
+        access_token.options[:grant_type] = :authorization_code
+        access_token.get('/v1/identity/openidconnect/userinfo', { :params => { :schema => 'openid'}}).parsed || {}
+      end
 
+      def prune!(hash)
+        hash.delete_if do |_, value|
+          prune!(value) if value.is_a?(Hash)
+          value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        end
+      end
+
+      def build_user_location
+        return unless raw_info['address']
+        location = [
+          raw_info['address']['locality'],
+          raw_info['address']['region']
+        ].compact.join(', ')
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/paypal_spec.rb
+++ b/spec/omniauth/strategies/paypal_spec.rb
@@ -6,6 +6,36 @@ describe OmniAuth::Strategies::PayPal do
     OmniAuth::Strategies::PayPal.new(nil, @options || {})
   end
 
+  let(:user_info_hash) {
+    {
+      'payer_id' => '6ZGXTKGQ3L35N',
+      'family_name' => 'Harkonnen',
+      'verified' => 'true',
+      'name' => 'Mikka Harkonnen',
+      'account_type' => 'PERSONAL',
+      'given_name' => 'Mikka',
+      'user_id' =>
+        'https://www.paypal.com/webapps/auth/identity/user/' \
+        'K43VMDJ6KaRJgMVUFRGT3hqpdnhg1tDYLmlPgxl1HRE',
+      'address' => {
+        'postal_code' => 'W12 4LQ',
+        'locality' => 'Wolverhampton',
+        'region' => 'West Midlands',
+        'country' => 'GB',
+        'street_address' => '1 Main Terrace'
+      },
+      'verified_account' => 'true',
+      'language' => 'en_GB',
+      'zoneinfo' => 'America/Los_Angeles',
+      'locale' => 'en_GB',
+      'phone_number' => '0356739226',
+      'account_creation_date' => '2016-08-30',
+      'email' => 'test2@login.com',
+      'age_range' => '36-40',
+      'birthday' => '1975-10-10'
+    }
+  }
+
   it_should_behave_like 'an oauth2 strategy'
 
   describe '#client' do
@@ -37,14 +67,72 @@ describe OmniAuth::Strategies::PayPal do
       counter = ''
       @options = { :setup => Proc.new { |env| counter = 'ok' } }
       subject.setup_phase
-      expect(counter).to eq("ok")
+      expect(counter).to eq('ok')
     end
   end
 
   describe '#callback_path' do
-    it "has the correct callback path" do
+    it 'has the correct callback path' do
       expect(subject.callback_path).to eq('/auth/paypal/callback')
     end
   end
 
+  describe '#uid' do
+    before do
+      allow(subject).to receive(:raw_info).and_return(user_info_hash)
+    end
+
+    it 'returns the final part of the PayPal user_id URL' do
+      expect(subject.uid).to eql('K43VMDJ6KaRJgMVUFRGT3hqpdnhg1tDYLmlPgxl1HRE')
+    end
+  end
+
+  describe '#info' do
+    before do
+      allow(subject).to receive(:raw_info).and_return(user_info_hash)
+    end
+
+    it 'includes the name' do
+      expect(subject.info[:name]).to eq(user_info_hash['name'])
+    end
+
+    it 'includes the first_name' do
+      expect(subject.info[:first_name]).to eq(user_info_hash['given_name'])
+    end
+
+    it 'includes the last_name' do
+      expect(subject.info[:last_name]).to eq(user_info_hash['family_name'])
+    end
+
+    it 'includes the email' do
+      expect(subject.info[:email]).to eq(user_info_hash['email'])
+    end
+
+    it 'includes the location as city and state when address exists' do
+      location = [
+        user_info_hash['address']['locality'],
+        user_info_hash['address']['region']
+      ].join(', ')
+      expect(subject.info[:location]).to eq(location)
+    end
+
+    it 'does not include the location when address does not exist' do
+      user_info_hash.delete('address')
+      expect(subject.info[:location]).to be_nil
+    end
+
+    it 'includes the phone' do
+      expect(subject.info[:phone]).to eq(user_info_hash['phone_number'])
+    end
+  end
+
+  describe '#extra' do
+    before do
+      allow(subject).to receive(:raw_info).and_return(user_info_hash)
+    end
+
+    it 'contains raw info as a hash value of :raw_info' do
+      expect(subject.extra).to eq({ 'raw_info' => user_info_hash })
+    end
+  end
 end


### PR DESCRIPTION
Omniauth describes the authentication hash schema for versions greater than 1.0 at https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema.

This pull request takes care of the following issues:
- the complete information about the user that Paypal sends is returned under `extra` -> `raw_info` instead of just `extra` as described in the Omniauth wiki
- redundant fields (`given_name` and `family_name`) are not returned under `info` as there already are clear, defined attributes for that kind of information (`first_name``last_name`). The fields are only kept as extra information about the user. The purpose of Omniauth is also to try and normalize different services

At the same time, tests are added for `#info` and `#extra` to verify compliance.
