### PR TITLE
PayPal OpenID & omniauth-oauth2 >= 1.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'omniauth-oauth2', "~> 1.3.1"
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,52 +2,52 @@ PATH
   remote: .
   specs:
     omniauth-paypal (1.3)
-      omniauth-oauth2 (~> 1.3.1)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.3.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
-    faraday (0.9.1)
+    diff-lcs (1.3)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    hashie (3.4.2)
-    json (1.8.3)
-    jwt (1.5.1)
-    multi_json (1.11.2)
-    multi_xml (0.5.5)
+    hashie (3.5.5)
+    json (2.0.3)
+    jwt (1.5.6)
+    multi_json (1.12.1)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
+    oauth2 (1.3.1)
+      faraday (>= 0.8, < 0.12)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
-    omniauth (1.2.2)
-      hashie (>= 1.2, < 4)
-      rack (~> 1.0)
-    omniauth-oauth2 (1.3.1)
+      rack (>= 1.2, < 3)
+    omniauth (1.6.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    rack (1.6.4)
-    rake (10.1.0)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.5)
-    rspec-expectations (2.14.3)
+    rack (2.0.1)
+    rake (12.0.0)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.3)
+    rspec-mocks (2.99.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   json
-  omniauth-oauth2 (~> 1.3.1)
   omniauth-paypal!
   rake
   rspec (~> 2.14)
 
 BUNDLED WITH
-   1.10.6
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Note:** This gem is designed to work with OmniAuth 1.0 library.
 
-This gem contains the Log In With PayPal strategy for OmniAuth.
+This gem contains the Log In With PayPal OpenID strategy for OmniAuth.
 
 ## Installing
 
@@ -33,25 +33,25 @@ The possible attributes to be returned at the moment are:
 ```ruby
 info['name']
 info['email']
-info['first_name'] # also available as given_name
-info['last_name'] # also available as family_name
+info['first_name']
+info['last_name']
 info['location']
 info['name']
 info['phone']
 
-extra['account_creation_date']
-extra['account_type']
-extra['address']['country']
-extra['address']['locality']
-extra['address']['postal_code']
-extra['address']['region']
-extra['address']['street_address']
-extra['language']
-extra['locale']
-extra['verified_account']
-extra['zoneinfo']
-extra['age_range']
-extra['birthday']
+extra['raw_info']['account_creation_date']
+extra['raw_info']['account_type']
+extra['raw_info']['address']['country']
+extra['raw_info']['address']['locality']
+extra['raw_info']['address']['postal_code']
+extra['raw_info']['address']['region']
+extra['raw_info']['address']['street_address']
+extra['raw_info']['language']
+extra['raw_info']['locale']
+extra['raw_info']['verified_account']
+extra['raw_info']['zoneinfo']
+extra['raw_info']['age_range']
+extra['raw_info']['birthday']
 ```
 
 The actual set of attributes returned depends on the scopes set. The currently available scopes are:
@@ -87,8 +87,6 @@ info:
   email: example@example.com
   first_name: John
   last_name: Smith
-  given_name: John
-  family_name: Smith
   location: Moscow
   name: John Smith
   phone: "71234567890"
@@ -98,21 +96,22 @@ credentials:
   expires_at: 1355082790
   expires: true
 extra:
-  account_creation_date: "2008-04-21"
-  account_type: PERSONAL
-  user_id: https://www.paypal.com/webapps/auth/identity/user/bathjJwvdhKjgfgh8Jd745J7dh5Qkgflbnczd65dfnw
-  address:
-    country: US
-    locality: San Jose
-    postal_code: "95131"
-    region: CA
-    street_address: 1 Main St
-  language: en_US
-  locale: en_US
-  verified_account: true
-  zoneinfo: America/Los_Angeles
-  age_range: 31-35
-  birthday: "1982-01-01"
+  raw_info:
+    account_creation_date: "2008-04-21"
+    account_type: PERSONAL
+    user_id: https://www.paypal.com/webapps/auth/identity/user/bathjJwvdhKjgfgh8Jd745J7dh5Qkgflbnczd65dfnw
+    address:
+      country: US
+      locality: San Jose
+      postal_code: "95131"
+      region: CA
+      street_address: 1 Main St
+    language: en_US
+    locale: en_US
+    verified_account: true
+    zoneinfo: America/Los_Angeles
+    age_range: 31-35
+    birthday: "1982-01-01"
 ```
 
 ## Contributing

--- a/lib/omniauth/strategies/paypal.rb
+++ b/lib/omniauth/strategies/paypal.rb
@@ -12,7 +12,6 @@ module OmniAuth
         :site          => 'https://api.paypal.com',
         :authorize_url => 'https://www.paypal.com/webapps/auth/protocol/openidconnect/v1/authorize',
         :token_url     => '/v1/identity/openidconnect/tokenservice',
-        :setup         => true
       }
 
       option :authorize_options, [:scope, :response_type]
@@ -23,30 +22,18 @@ module OmniAuth
 
       info do
         prune!({
-                   'name' => raw_info['name'],
-                   'email' => raw_info['email'],
-                   'first_name' => raw_info['given_name'],
-                   'last_name' => raw_info['family_name'],
-                   'given_name' => raw_info['given_name'],
-                   'family_name' => raw_info['family_name'],
-                   'location' => (raw_info['address'] || {})['locality'],
-                   'phone' => raw_info['phone_number']
-               })
+          name: raw_info['name'],
+          email: raw_info['email'],
+          first_name: raw_info['given_name'],
+          last_name: raw_info['family_name'],
+          location: build_user_location,
+          phone: raw_info['phone_number'],
+          image: raw_info['picture']
+        })
       end
 
       extra do
-        prune!({
-                   'account_type' => raw_info['account_type'],
-                   'user_id' => raw_info['user_id'],
-                   'address' => raw_info['address'],
-                   'verified_account' => (raw_info['verified_account'] == 'true'),
-                   'language' => raw_info['language'],
-                   'zoneinfo' => raw_info['zoneinfo'],
-                   'locale' => raw_info['locale'],
-                   'account_creation_date' => raw_info['account_creation_date'],
-                   'age_range' => raw_info['age_range'],
-                   'birthday' => raw_info['birthday']
-               })
+        prune!({'raw_info' => raw_info})
       end
 
       def setup_phase
@@ -57,8 +44,12 @@ module OmniAuth
         super
       end
 
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
+
       def raw_info
-        @raw_info ||= load_identity()
+        @raw_info ||= load_identity
       end
 
       def authorize_params
@@ -68,21 +59,51 @@ module OmniAuth
         end
       end
 
+      def custom_build_access_token
+        access_token =
+        if request.xhr? && request.params['code']
+          verifier = request.params['code']
+          redirect_uri = request.params['redirect_uri'] || 'postmessage'
+          client.auth_code.get_token(verifier, get_token_options(redirect_uri), deep_symbolize(options.auth_token_params || {}))
+        elsif request.params['code'] && request.params['redirect_uri']
+          verifier = request.params['code']
+          redirect_uri = request.params['redirect_uri']
+          client.auth_code.get_token(verifier, get_token_options(redirect_uri), deep_symbolize(options.auth_token_params || {}))
+        else
+          verifier = request.params["code"]
+          client.auth_code.get_token(verifier, get_token_options(callback_url), deep_symbolize(options.auth_token_params))
+        end
+        access_token
+      end
+      alias_method :build_access_token, :custom_build_access_token
+
       private
-        def load_identity
-          access_token.options[:mode] = :query
-          access_token.options[:param_name] = :access_token
-          access_token.options[:grant_type] = :authorization_code
-          access_token.get('/v1/identity/openidconnect/userinfo', { :params => { :schema => 'openid'}}).parsed || {}
-        end
 
-        def prune!(hash)
-          hash.delete_if do |_, value|
-            prune!(value) if value.is_a?(Hash)
-            value.nil? || (value.respond_to?(:empty?) && value.empty?)
-          end
-        end
+      def load_identity
+        access_token.options[:mode] = :query
+        access_token.options[:param_name] = :access_token
+        access_token.options[:grant_type] = :authorization_code
+        access_token.get('/v1/identity/openidconnect/userinfo', { :params => { :schema => 'openid'}}).parsed || {}
+      end
 
+      def get_token_options(redirect_uri)
+        { :redirect_uri => redirect_uri }.merge(token_params.to_hash(:symbolize_keys => true))
+      end
+
+      def prune!(hash)
+        hash.delete_if do |_, value|
+          prune!(value) if value.is_a?(Hash)
+          value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        end
+      end
+
+      def build_user_location
+        return unless raw_info['address']
+        location = [
+          raw_info['address']['locality'],
+          raw_info['address']['region']
+        ].compact.join(', ')
+      end
     end
   end
 end

--- a/omniauth-paypal.gemspec
+++ b/omniauth-paypal.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.3.1'
+  s.add_runtime_dependency 'omniauth', '>= 1.1.1'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.3.1'
 
   s.add_development_dependency 'rspec', '~> 2.14'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
1. Works with PayPal's OpenID and generates access_token from code prior to requesting userinfo
2. omniauth-oauth2 version  >=1.3.1